### PR TITLE
removed extraneous character from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Note that the materials in the Software Carpentry [bc repo](https://github.com/s
 If you'd like to contribute new matieral to our lessons repo, follow these steps:  
 
 1. [Fork](https://help.github.com/articles/fork-a-repo) the lessons repository.
-2. Create a new[branch and make all your changes/edits on that branch (i.e. do not make your changes on the `master` branch, as this makes it difficult to merge later on). If your edits are for a particular discipline and bootcamp, make that explicit in the branch name (e.g. `2014-02-30-meteorology-bootcamp`).
+2. Create a new branch and make all your changes/edits on that branch (i.e. do not make your changes on the `master` branch, as this makes it difficult to merge later on). If your edits are for a particular discipline and bootcamp, make that explicit in the branch name (e.g. `2014-02-30-meteorology-bootcamp`).
 3. Once you're done, submit a [pull request](https://help.github.com/articles/using-pull-requests) and we'll review your changes.
 
 ### Bootcamp resources


### PR DESCRIPTION
There was an extra character in the lesson's README. Also, I was confirming the git pull request workflow.